### PR TITLE
build(docker): use Chinese registry sources for all images

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   # Test Database Services
   postgres-test:
-    image: postgres:15-alpine
+    image: crpi-uq4h40nqjrf2s1wo.cn-qingdao.personal.cr.aliyuncs.com/ghcr_io/postgres:15-alpine
     container_name: portfolio_postgres_test
     environment:
       POSTGRES_DB: portfolio_test_db
@@ -22,7 +22,7 @@ services:
       retries: 5
 
   redis-test:
-    image: redis:7-alpine
+    image: crpi-uq4h40nqjrf2s1wo.cn-qingdao.personal.cr.aliyuncs.com/ghcr_io/redis:7-alpine
     container_name: portfolio_redis_test
     ports:
       - "6380:6379"
@@ -35,7 +35,7 @@ services:
       retries: 3
 
   nats-test:
-    image: nats:2.10-alpine
+    image: crpi-uq4h40nqjrf2s1wo.cn-qingdao.personal.cr.aliyuncs.com/ghcr_io/nats:2.10-alpine
     container_name: portfolio_nats_test
     ports:
       - "4223:4222"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # Database Services
   postgres:
-    image: postgres:15-alpine
+    image: crpi-uq4h40nqjrf2s1wo.cn-qingdao.personal.cr.aliyuncs.com/ghcr_io/postgres:15-alpine
     container_name: portfolio_postgres
     environment:
       POSTGRES_DB: portfolio_db
@@ -21,7 +21,7 @@ services:
       retries: 3
 
   redis:
-    image: redis:7-alpine
+    image: crpi-uq4h40nqjrf2s1wo.cn-qingdao.personal.cr.aliyuncs.com/ghcr_io/redis:7-alpine
     container_name: portfolio_redis
     ports:
       - "6379:6379"
@@ -37,7 +37,7 @@ services:
 
   # Message Broker
   nats:
-    image: nats:2.10-alpine
+    image: crpi-uq4h40nqjrf2s1wo.cn-qingdao.personal.cr.aliyuncs.com/ghcr_io/nats:2.10-alpine
     container_name: portfolio_nats
     ports:
       - "4222:4222"

--- a/services/api-gateway/Dockerfile
+++ b/services/api-gateway/Dockerfile
@@ -1,13 +1,17 @@
 # Build stage
-FROM golang:1.22.4-alpine AS builder
+FROM crpi-uq4h40nqjrf2s1wo.cn-qingdao.personal.cr.aliyuncs.com/ghcr_io/golang:1.22.4-alpine AS builder
 
 WORKDIR /app
 
 # Install dependencies for building
-RUN apk add --no-cache git ca-certificates tzdata
+# Use Chinese mirror for Alpine packages
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories && \
+    apk add --no-cache git ca-certificates tzdata
 
 # Copy go mod files
 COPY go.mod go.sum ./
+# Use Chinese proxy for Go modules
+ENV GOPROXY=https://goproxy.cn,direct
 RUN go mod download && go mod verify
 
 # Copy source code
@@ -20,7 +24,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     -o main .
 
 # Final stage using distroless for maximum security
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM crpi-uq4h40nqjrf2s1wo.cn-qingdao.personal.cr.aliyuncs.com/ghcr_io/static-debian12:nonroot
 
 # Copy timezone data and ca-certificates from builder
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo


### PR DESCRIPTION
## 📋 Pull Request Summary

**Type of Change**
- [x] 🔧 Build/CI (`build`/`ci`)

**Service/Component**
- [x] Infrastructure/Docker

## 🎯 Description

Updated all Docker configurations to use Chinese registry sources:
- Update base images in Dockerfile to use Chinese mirrors
- Configure Alpine package manager to use Aliyun mirror
- Set Go modules proxy to goproxy.cn
- Replace distroless image with Chinese mirror
- Update docker-compose services to use Chinese images

Ensures all container builds and dependencies are sourced from within China for faster builds and compliance with local regulations.

## 🔗 Related Issues
N/A (Infrastructure improvement)

## 🧪 Testing

**Manual Testing Steps:**
1. Build containers locally using `docker-compose build`
2. Verify all images pull successfully from Chinese sources
3. Confirm application runs normally with new configurations

**Automated Tests:**
- [x] All tests pass locally

## ✅ Checklist

**Code Quality:**
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Code is properly commented
- [x] No console.log or debug statements left

**Testing:**
- [x] Manual testing completed

**Documentation:**
- [x] README updated if needed

## 🚀 Deployment Notes
No special deployment considerations - changes only affect build process

## 📝 Additional Notes
This change improves build speeds for developers in China and ensures compliance with local regulations.